### PR TITLE
fix: toMetric return statement syntax error

### DIFF
--- a/src/newrelic-metrics.rsc
+++ b/src/newrelic-metrics.rsc
@@ -126,7 +126,7 @@
 }
 
 :local toMetric do={
-    :ret {"name"=$name; "value"=$value; "type"="gauge"};
+    :return {"name"=$name; "value"=$value; "type"="gauge"};
 }
 
 ##### END HELPER METHODS ########################################


### PR DESCRIPTION
[admin@MikroTik] > /system/script/run newrelic-metrics
syntax error (line 128 column 10)

[admin@MikroTik] > /system/package/print
Columns: NAME, VERSION
0 routeros  7.4

Signed-off-by: Mikhail Ushanov <gm.mephisto@gmail.com>