### PR TITLE
fix: Data rejected because `mikrotik.ip` includes invalid keys

### DIFF
--- a/src/newrelic-metrics.rsc
+++ b/src/newrelic-metrics.rsc
@@ -63,7 +63,17 @@
 # Calculates a millisecond-based timestamp value
 # @returns Timestamp value
 :local getTimestamp do={
-   :return (1000 * [:tonum [:timestamp]])
+   :local ds [/system clock get date];
+   :local months;
+   :if ((([:pick $ds 9 11]-1)/4) != (([:pick $ds 9 11])/4)) do={
+      :set months {"an"=0;"eb"=31;"ar"=60;"pr"=91;"ay"=121;"un"=152;"ul"=182;"ug"=213;"ep"=244;"ct"=274;"ov"=305;"ec"=335};
+   } else={
+      :set months {"an"=0;"eb"=31;"ar"=59;"pr"=90;"ay"=120;"un"=151;"ul"=181;"ug"=212;"ep"=243;"ct"=273;"ov"=304;"ec"=334};
+   }
+   :set ds (([:pick $ds 9 11]*365)+(([:pick $ds 9 11]-1)/4)+($months->[:pick $ds 1 3])+[:pick $ds 4 6]);
+   :local ts [/system clock get time];
+   :set ts (([:pick $ts 0 2]*60*60)+([:pick $ts 3 5]*60)+[:pick $ts 6 8]);
+   :return ($ds*24*60*60 + $ts + 946684800 - [/system clock get gmt-offset]);
 };
 
 # Searializes a metrics object to NR metrics json format

--- a/src/newrelic-metrics.rsc
+++ b/src/newrelic-metrics.rsc
@@ -6,7 +6,6 @@
 
 ##### START CONFIG ##############################################
 
-
 # Retrieve your New Relic API key -see README.
 :local NRAPIKEY "NRII-Abc123"
 

--- a/src/newrelic-metrics.rsc
+++ b/src/newrelic-metrics.rsc
@@ -6,6 +6,7 @@
 
 ##### START CONFIG ##############################################
 
+
 # Retrieve your New Relic API key -see README.
 :local NRAPIKEY "NRII-Abc123"
 
@@ -23,6 +24,7 @@
     "mikrotik.model"=[/system routerboard get model];
     "mikrotik.currentfirmware"=[/system routerboard get current-firmware];
     "mikrotik.upgradefirmware"=[/system routerboard get upgrade-firmware];
+    "mikrotik.ip"=[/ip address get [find interface="ether1"] address];
 }
 
 # These are metrics of the entity created in NR -can be charted, used for alerting, etc
@@ -31,7 +33,6 @@
     "mikrotik.system.memory.total"=[/system resource get total-memory];
     "mikrotik.system.memory.free"=[/system resource get free-memory];
     "mikrotik.system.memory.load"=100 - (100 * [/system resource get free-memory] / [/system resource get total-memory])
-    "mikrotik.ip"=[/ip address get [find interface="ether1"] address];
     "mikrotik.ip.pool.used"=[/ip pool used print count-only];
     "mikrotik.ip.dns.cache.size"=[/ip dns get cache-size];
     "mikrotik.ip.dns.cache.used"=[/ip dns get cache-used];
@@ -63,17 +64,7 @@
 # Calculates a millisecond-based timestamp value
 # @returns Timestamp value
 :local getTimestamp do={
-   :local ds [/system clock get date];
-   :local months;
-   :if ((([:pick $ds 9 11]-1)/4) != (([:pick $ds 9 11])/4)) do={
-      :set months {"an"=0;"eb"=31;"ar"=60;"pr"=91;"ay"=121;"un"=152;"ul"=182;"ug"=213;"ep"=244;"ct"=274;"ov"=305;"ec"=335};
-   } else={
-      :set months {"an"=0;"eb"=31;"ar"=59;"pr"=90;"ay"=120;"un"=151;"ul"=181;"ug"=212;"ep"=243;"ct"=273;"ov"=304;"ec"=334};
-   }
-   :set ds (([:pick $ds 9 11]*365)+(([:pick $ds 9 11]-1)/4)+($months->[:pick $ds 1 3])+[:pick $ds 4 6]);
-   :local ts [/system clock get time];
-   :set ts (([:pick $ts 0 2]*60*60)+([:pick $ts 3 5]*60)+[:pick $ts 6 8]);
-   :return ($ds*24*60*60 + $ts + 946684800 - [/system clock get gmt-offset]);
+   :return (1000 * [:tonum [:timestamp]])
 };
 
 # Searializes a metrics object to NR metrics json format


### PR DESCRIPTION
At some point, NR started rejecting the data because o the `ip` field

- Message: One or more metrics rejected because they included invalid keys. For more info visit https://docs.newrelic.com/docs/troubleshoot-nrintegrationerror-events
- Metric Name Sample: `mikrotik.ip`