### PR TITLE
feat: Simplify `getTimestamp`

### DIFF
--- a/src/newrelic-metrics.rsc
+++ b/src/newrelic-metrics.rsc
@@ -63,17 +63,7 @@
 # Calculates a millisecond-based timestamp value
 # @returns Timestamp value
 :local getTimestamp do={
-   :local ds [/system clock get date];
-   :local months;
-   :if ((([:pick $ds 9 11]-1)/4) != (([:pick $ds 9 11])/4)) do={
-      :set months {"an"=0;"eb"=31;"ar"=60;"pr"=91;"ay"=121;"un"=152;"ul"=182;"ug"=213;"ep"=244;"ct"=274;"ov"=305;"ec"=335};
-   } else={
-      :set months {"an"=0;"eb"=31;"ar"=59;"pr"=90;"ay"=120;"un"=151;"ul"=181;"ug"=212;"ep"=243;"ct"=273;"ov"=304;"ec"=334};
-   }
-   :set ds (([:pick $ds 9 11]*365)+(([:pick $ds 9 11]-1)/4)+($months->[:pick $ds 1 3])+[:pick $ds 4 6]);
-   :local ts [/system clock get time];
-   :set ts (([:pick $ts 0 2]*60*60)+([:pick $ts 3 5]*60)+[:pick $ts 6 8]);
-   :return ($ds*24*60*60 + $ts + 946684800 - [/system clock get gmt-offset]);
+  :return (1000 * [:tonum [:timestamp]])
 };
 
 # Searializes a metrics object to NR metrics json format


### PR DESCRIPTION
With RouterOs 7, it's straightforward to get a Unix Timetamp